### PR TITLE
Handle notificationType field instead of eventType

### DIFF
--- a/src/App/Http/Controllers/BaseController.php
+++ b/src/App/Http/Controllers/BaseController.php
@@ -125,6 +125,10 @@ class BaseController extends Controller implements BaseControllerContract
         // At this point we have a valid SNS notification message.
         $message = json_decode($body->Message);
 
+        if (!isset($message->eventType)) {
+            $message->eventType = $message->notificationType;
+        }
+
         // The SES event notification has a Message property that should be a object when decoded.
         if (!is_object($message)) {
             Log::error('Result message failed to decode: '.json_last_error_msg());

--- a/src/App/Http/Controllers/BaseController.php
+++ b/src/App/Http/Controllers/BaseController.php
@@ -125,15 +125,16 @@ class BaseController extends Controller implements BaseControllerContract
         // At this point we have a valid SNS notification message.
         $message = json_decode($body->Message);
 
-        if (!isset($message->eventType)) {
-            $message->eventType = $message->notificationType;
-        }
-
         // The SES event notification has a Message property that should be a object when decoded.
         if (!is_object($message)) {
             Log::error('Result message failed to decode: '.json_last_error_msg());
 
             return response()->json(['success' => false], 422);
+        }
+
+        // Handle notificationType field that can be present instead of eventType
+        if (!isset($message->eventType)) {
+            $message->eventType = $message->notificationType;
         }
 
         return $message;


### PR DESCRIPTION
AWS recently introduced [a different way](https://aws.amazon.com/blogs/messaging-and-targeting/handling-bounces-and-complaints/) for handling Bounces and Complaints and changed the expected [structure of the data](https://docs.aws.amazon.com/ses/latest/dg/event-publishing-retrieving-sns-contents.html#event-publishing-retrieving-sns-contents-mail-object) based on whether it is an event or notification.

With the change from this PR, the change will be gracefully handled by populating the possibly missing object property.